### PR TITLE
feat: Remove Google Fonts links from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,12 +16,6 @@
     <meta property="og:image" content="/og-image.png" />
     <meta name="google-site-verification" content="u8tUHGiTRGGTAfUVyhv25LtxJQUmd5jEP3PClu87SMs" />
     <link rel="icon" href="/lovable-uploads/favicon.ico" type="image/x-icon" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Raleway:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
   </head>
 
   <body>


### PR DESCRIPTION
Removes the link tags that load Poppins and Raleway fonts from Google Fonts. The fonts are now self-hosted and loaded via CSS, so these links are no longer necessary.