### PR TITLE
Fix: Remove irrelevant font formats from CSS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,77 +1,5 @@
 @font-face {
   font-family: 'Poppins';
-  src: url('/fonts/poppins/Poppins-Thin.woff2') format('woff2'),
-       url('/fonts/poppins/Poppins-Thin.woff') format('woff');
-  font-weight: 100;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Poppins';
-  src: url('/fonts/poppins/Poppins-ExtraLight.woff2') format('woff2'),
-       url('/fonts/poppins/Poppins-ExtraLight.woff') format('woff');
-  font-weight: 200;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Poppins';
-  src: url('/fonts/poppins/Poppins-Light.woff2') format('woff2'),
-       url('/fonts/poppins/Poppins-Light.woff') format('woff');
-  font-weight: 300;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Poppins';
-  src: url('/fonts/poppins/Poppins-Regular.woff2') format('woff2'),
-       url('/fonts/poppins/Poppins-Regular.woff') format('woff');
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Poppins';
-  src: url('/fonts/poppins/Poppins-Medium.woff2') format('woff2'),
-       url('/fonts/poppins/Poppins-Medium.woff') format('woff');
-  font-weight: 500;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Poppins';
-  src: url('/fonts/poppins/Poppins-SemiBold.woff2') format('woff2'),
-       url('/fonts/poppins/Poppins-SemiBold.woff') format('woff');
-  font-weight: 600;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Poppins';
-  src: url('/fonts/poppins/Poppins-Bold.woff2') format('woff2'),
-       url('/fonts/poppins/Poppins-Bold.woff') format('woff');
-  font-weight: 700;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Poppins';
-  src: url('/fonts/poppins/Poppins-ExtraBold.woff2') format('woff2'),
-       url('/fonts/poppins/Poppins-ExtraBold.woff') format('woff');
-  font-weight: 800;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Poppins';
-  src: url('/fonts/poppins/Poppins-Black.woff2') format('woff2'),
-       url('/fonts/poppins/Poppins-Black.woff') format('woff');
-  font-weight: 900;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Poppins';
   src: url('/fonts/poppins/Poppins-Light.ttf') format('truetype');
   font-weight: 300;
   font-style: normal;
@@ -105,80 +33,15 @@
   font-style: normal;
   font-display: swap;
 }
+@font-face {
+  font-family: 'Poppins';
+  src: url('/fonts/poppins/Poppins-Italic.ttf') format('truetype');
+  font-weight: normal;
+  font-style: italic;
+  font-display: swap;
+}
 
 /* Raleway weights */
-@font-face {
-  font-family: 'Raleway';
-  src: url('/fonts/raleway/Raleway-Thin.woff2') format('woff2'),
-       url('/fonts/raleway/Raleway-Thin.woff') format('woff');
-  font-weight: 100;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Raleway';
-  src: url('/fonts/raleway/Raleway-ExtraLight.woff2') format('woff2'),
-       url('/fonts/raleway/Raleway-ExtraLight.woff') format('woff');
-  font-weight: 200;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Raleway';
-  src: url('/fonts/raleway/Raleway-Light.woff2') format('woff2'),
-       url('/fonts/raleway/Raleway-Light.woff') format('woff');
-  font-weight: 300;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Raleway';
-  src: url('/fonts/raleway/Raleway-Regular.woff2') format('woff2'),
-       url('/fonts/raleway/Raleway-Regular.woff') format('woff');
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Raleway';
-  src: url('/fonts/raleway/Raleway-Medium.woff2') format('woff2'),
-       url('/fonts/raleway/Raleway-Medium.woff') format('woff');
-  font-weight: 500;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Raleway';
-  src: url('/fonts/raleway/Raleway-SemiBold.woff2') format('woff2'),
-       url('/fonts/raleway/Raleway-SemiBold.woff') format('woff');
-  font-weight: 600;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Raleway';
-  src: url('/fonts/raleway/Raleway-Bold.woff2') format('woff2'),
-       url('/fonts/raleway/Raleway-Bold.woff') format('woff');
-  font-weight: 700;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Raleway';
-  src: url('/fonts/raleway/Raleway-ExtraBold.woff2') format('woff2'),
-       url('/fonts/raleway/Raleway-ExtraBold.woff') format('woff');
-  font-weight: 800;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'Raleway';
-  src: url('/fonts/raleway/Raleway-Black.woff2') format('woff2'),
-       url('/fonts/raleway/Raleway-Black.woff') format('woff');
-  font-weight: 900;
-  font-style: normal;
-  font-display: swap;
-}
 @font-face {
   font-family: 'Raleway';
   src: url('/fonts/raleway/Raleway-Thin.ttf') format('truetype');


### PR DESCRIPTION
This change removes the `woff` and `woff2` font formats from the `src/index.css` file and updates the `@font-face` declarations to use the available `.ttf` fonts.

The original CSS file contained `@font-face` rules for `woff` and `woff2` font files that do not exist in the project. This change removes those declarations and ensures that the CSS only references the `.ttf` font files that are present in the `public/fonts` directory.

This resolves the issue of the browser making unnecessary requests for font files that do not exist.